### PR TITLE
Respect user's theme preference on load

### DIFF
--- a/jquery.js
+++ b/jquery.js
@@ -1,35 +1,38 @@
+function setLightTheme() {
+    $('.navbar.navbar-expand-lg.navbar-light').addClass('bg-light');
+    $('#title1').css({ "color": "black" });
+    $('body').css({ "background": "linear-gradient(to right, #191654, #43C6AC)" })
+    $('.digit').css({ "color": "white" })
+    $('#light').prop("checked", false);
+}
+
+function setDarkTheme() {
+    $('.navbar.navbar-expand-lg.navbar-light').removeClass('bg-light');
+    $('.navbar.navbar-expand-lg.navbar-light').css({ "background-color": "black" });
+    $('#title1').css({ "color": "white" });
+    $('body').css({ "background": "#191212" });
+    $('.digit').css({ "color": "rgb(216 137 31)" });
+    $('#light').prop("checked", true);
+}
+
 $(document).ready(function ()
 {
 
     if (localStorage.getItem("darkmode") == "true")
     {
-        $('.navbar.navbar-expand-lg.navbar-light').removeClass('bg-light');
-        $('.navbar.navbar-expand-lg.navbar-light').css({ "background-color": "black" });
-        $('#title1').css({ "color": "white" });
-        $('body').css({ "background": "#191212" })
-        $('.digit').css({ "color": "rgb(216 137 31)" })
-        $('#light').click();
+        setDarkTheme();
     }
 
     $('#light').on("change paste keyup", function (e)
     {
         if (!e.target.checked)
         {
-            $('.navbar.navbar-expand-lg.navbar-light').addClass('bg-light');
-
-            $('#title1').css({ "color": "black" });
-            $('body').css({ "background": "linear-gradient(to right, #191654, #43C6AC)" })
-            $('.digit').css({ "color": "white" })
-
+            setLightTheme();
             localStorage.setItem("darkmode", false);
         }
         else
         {
-            $('.navbar.navbar-expand-lg.navbar-light').removeClass('bg-light');
-            $('.navbar.navbar-expand-lg.navbar-light').css({ "background-color": "black" });
-            $('#title1').css({ "color": "white" });
-            $('body').css({ "background": "#191212" })
-            $('.digit').css({ "color": "rgb(216 137 31)" })
+            setDarkTheme();
             localStorage.setItem("darkmode", true);
         }
     });

--- a/jquery.js
+++ b/jquery.js
@@ -17,6 +17,14 @@ function setDarkTheme() {
 
 var prefersDarkThemeMql = window.matchMedia("(prefers-color-scheme: dark)");
 
+prefersDarkThemeMql.addEventListener("change", function(mql) {
+    if (localStorage.getItem("darkmode") === null && mql.matches) {
+        setDarkTheme();
+    } else {
+        setLightTheme();
+    }
+})
+
 $(document).ready(function ()
 {
 

--- a/jquery.js
+++ b/jquery.js
@@ -15,10 +15,15 @@ function setDarkTheme() {
     $('#light').prop("checked", true);
 }
 
+var prefersDarkThemeMql = window.matchMedia("(prefers-color-scheme: dark)");
+
 $(document).ready(function ()
 {
 
-    if (localStorage.getItem("darkmode") == "true")
+    if (
+        localStorage.getItem("darkmode") == "true" ||
+        (localStorage.getItem("darkmode") === null && prefersDarkThemeMql.matches)
+    )
     {
         setDarkTheme();
     }


### PR DESCRIPTION
Resolves #73.

The site will now load the correct theme to match user's system-level theme preferences via prefers-color-scheme media query. It will also listen to the media query and change the theme if the preference gets updated while the site is open.
The user can permanently override their system-level setting by using the theme toggle on the site itself.
I also moved the theme change logic to separate functions to avoid repeating code.