### PR TITLE
feat: shortcut key support added

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,18 @@
   <br>
 - The functionalities of **Start, Stop, Reset, Lap, and Clear Lap** are accessible with a click of a button.
   <br>
-- To enhance the visual appearance it can be viewed in **both dark and light modes,** making it easier to access at all times, along with having a responsive website to maximize the user experience.
+- **Keyboard shortcuts** are now available for enhanced productivity:
+  - **Space** or **P** - Start/Stop the stopwatch
+  - **Backspace** or **R** - Reset the stopwatch
+  - **Enter** - Add a lap
+  - **Numpad 0** - Clear all laps
+  - **K** - Play/Pause background music
+  <br>
+- **Custom Timer** with enhanced UI features including time completion animations, sound alerts, and confetti celebrations.
+  <br>
+- **Pomodoro Timer** with consistent styling and footer layout across all pages.
+  <br>
+- To enhance the visual appearance it can be viewed in **both dark and light modes,** making it easier to access at all times, along with a responsive website to maximize the user experience.
   <br>
 
 

--- a/index.html
+++ b/index.html
@@ -154,6 +154,31 @@
         clearLap();
       }
     });
+
+    // P key for Start/Stop
+    document.addEventListener("keyup", (event) => {
+      if (event.code === "KeyP") {
+        start();
+      }
+    });
+
+    // R key for Reset
+    document.addEventListener("keyup", (event) => {
+      if (event.code === "KeyR") {
+        reset();
+      }
+    });
+
+    // K key for Play/Pause music
+    document.addEventListener("keyup", (event) => {
+      if (event.code === "KeyK") {
+        if (audio.paused) {
+          audio.play();
+        } else {
+          audio.pause();
+        }
+      }
+    });
   </script>
   <script src="script.js"></script>
 


### PR DESCRIPTION
This PR introduces keyboard shortcuts to improve user experience and productivity:

P → Start/Stop the stopwatch

R → Reset the stopwatch


These shortcuts make interacting with the stopwatch faster and more convenient without relying solely on buttons.

#234 