### PR TITLE
fix theme inconsistency

### DIFF
--- a/custom_timer/timer.html
+++ b/custom_timer/timer.html
@@ -51,8 +51,8 @@
       <div class="collapse navbar-collapse" id="navbarSupportedContent">
         <ul class="navbar-nav mr-auto">
           <li class="nav-item px-4">
-            <a class="nav-link btn secondary" href="../index.html">STOP WATCH</a>
-            <a class="nav-link btn secondary" href="../pomodoro/index.html">POMODORO TIMER</a>
+            <a class="nav-link btn secondary " id="link--active" href="../index.html">STOP WATCH</a>
+            <a class="nav-link btn secondary" id="link--active" href="../pomodoro/index.html">POMODORO TIMER</a>
             <a class="nav-link btn secondary" id="link--active" href="#">CUSTOM TIMER</a>
           </li>
         </ul>


### PR DESCRIPTION
Before
<img width="1907" height="873" alt="Screenshot 2025-10-06 185322" src="https://github.com/user-attachments/assets/cab58756-82f9-49ec-bbb5-cef425b8bac5" />

Fixed the issue where text was hiding on Stopwatch and Custom Timer pages.
Now the theme loads properly without needing to toggle twice.

After
<img width="1910" height="810" alt="Screenshot 2025-10-06 190628" src="https://github.com/user-attachments/assets/5e057162-39ea-4aa3-940f-ced887118ca4" />

Fixes #249