### PR TITLE
Added safe contact email in footer

### DIFF
--- a/pomodoro/index.html
+++ b/pomodoro/index.html
@@ -535,6 +535,10 @@ body:not(.dark-mode) .toggle-switch-label {
   <div class="container-fluid my-class foot">
     <div class="container">
       <p class="textfooter" style="margin-top: 2rem;">Made with <span class="heart">❤️</span> by Avinash Singh</p>
+      <p class="textfooter" style="margin-top: 1rem;">
+        <i class="fas fa-envelope"></i>
+        <a href="mailto:iswarya952@users.noreply.github.com" style="color:white; text-decoration:none;">Contact Me</a>
+      </p>
 
       <div>
         <ul style="color: white" class="social-links">


### PR DESCRIPTION
This update adds a safe GitHub noreply email link in the footer of the Pomodoro timer page.  
Purpose: Users can contact the project maintainers without exposing personal email addresses.  

Changes:  
- Added a "Contact Me" link with `iswarya952@users.noreply.github.com` in `pomodoro/index.html`.  

No deletions or functional changes to the existing code.
