### PR TITLE
Fix lap table error: Replace insertCell with insertRow for table body

### DIFF
--- a/script.js
+++ b/script.js
@@ -354,7 +354,7 @@ function lap() {
 
     const table = $id("record-table-body");
     if (table) {
-      const row = table.insertCell(0);
+      const row = table.insertRow(0);
       const no_cell = row.insertCell(0);
       const time_cell = row.insertCell(1);
       const diff_cell = row.insertCell(2);


### PR DESCRIPTION
# Fix: Resolve lap table insertion error

## Summary
This pull request fixes a critical bug in the lap functionality where attempting to record lap times would throw a `TypeError: table.insertCell is not a function` error.

**Fixes #384 - Critical: Lap recording fails with DOM manipulation error**

## Problem
The `lap()` function in `script.js` was incorrectly trying to call `insertCell()` directly on a table body element (`<tbody>`). The `insertCell()` method is only available on table row elements (`<tr>`), not on table body elements.

## Solution
Changed the DOM manipulation approach to:
1. First create a new table row using `insertRow(0)` on the table body
2. Then create cells using `insertCell()` on the newly created row

## Changes Made
**File:** `script.js`  
**Line:** 357

### Before (Broken):

<img width="1253" height="1130" alt="Screenshot 2025-10-25 153020" src="https://github.com/user-attachments/assets/78b22886-7a54-433e-a937-e9aaa500736e" />

```javascript
const table = $id("record-table-body");
if (table) {
  const row = table.insertCell(0); // ❌ Incorrect - insertCell on tbody
  const no_cell = row.insertCell(0);
  const time_cell = row.insertCell(1);
  const diff_cell = row.insertCell(2);
}
```

### After (Fixed):

<img width="1267" height="1111" alt="Screenshot 2025-10-25 152938" src="https://github.com/user-attachments/assets/cc4887e7-eae9-4a45-9d20-25b201af6c9e" />

```javascript
const table = $id("record-table-body");
if (table) {
  const row = table.insertRow(0); // ✅ Correct - insertRow on tbody
  const no_cell = row.insertCell(0);
  const time_cell = row.insertCell(1);
  const diff_cell = row.insertCell(2);
}
```

## Testing
- ✅ Stopwatch starts and stops correctly
- ✅ Lap button now works without errors
- ✅ Lap times are properly recorded and displayed
- ✅ Lap differences are calculated correctly
- ✅ No JavaScript errors in console
- ✅ All existing functionality remains intact

## Impact
- **Fixes:** Critical lap timing functionality
- **Affects:** Users can now successfully record lap times
- **Compatibility:** Works across all modern browsers
- **Breaking Changes:** None

## Verification Steps
1. Start the stopwatch
2. Click the "Lap" button multiple times
3. Verify lap times appear in the table
4. Check browser console for no errors
5. Confirm lap differences are calculated correctly

